### PR TITLE
add separate message for permabans

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -288,10 +288,12 @@ const talkedRecently = new Set();
     });
 })();
 
-kb.on("timeout", (channel, username, message, duration) => {
+kb.on("timeout", (channel, username, message, duration, msg) => {
     if (channel === "#supinic") {
         if (duration == '1') {
             kb.say(channel, `${username} vanished Article13 MagicTime`)
+        } else if (msg.isPermaban()){
+            kb.say(channe, `${username} has been permanently banned MODS Clap`);
         } else {
             kb.say(channel, `${username} has been timed out for ${duration}s Article13 MagicTime`)
         }


### PR DESCRIPTION
Currently when a permaban happens in supu's channel ksyncbot says "xy has been timed out for undefineds Article13 MagicTime" as the length is undefined if the ban is permanent. Using the passed (but previously unused) [ClearchatMessage](https://robotty.github.io/dank-twitch-irc/classes/clearchatmessage.html#ispermaban) object's `isPermaban() `method this determines if the ban was a perma and outputs a different message in this case.